### PR TITLE
Send only needed headers

### DIFF
--- a/bounce.go
+++ b/bounce.go
@@ -34,9 +34,9 @@ func (client *Client) GetDeliveryStats() (DeliveryStats, error) {
 	res := DeliveryStats{}
 	path := "deliverystats"
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               path,
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      path,
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -98,9 +98,9 @@ func (client *Client) GetBounces(count int64, offset int64, options map[string]i
 	path := fmt.Sprintf("bounces?%s", values.Encode())
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               path,
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      path,
+		TokenType: server_token,
 	}, &res)
 	return res.Bounces, res.TotalCount, err
 }
@@ -113,9 +113,9 @@ func (client *Client) GetBounce(bounceID int64) (Bounce, error) {
 	res := Bounce{}
 	path := fmt.Sprintf("bounces/%v", bounceID)
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               path,
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      path,
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -132,9 +132,9 @@ func (client *Client) GetBounceDump(bounceID int64) (string, error) {
 	res := dumpResponse{}
 	path := fmt.Sprintf("bounces/%v/dump", bounceID)
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               path,
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      path,
+		TokenType: server_token,
 	}, &res)
 	return res.Body, err
 }
@@ -154,9 +154,9 @@ func (client *Client) ActivateBounce(bounceID int64) (Bounce, string, error) {
 	res := activateBounceResponse{}
 	path := fmt.Sprintf("bounces/%v/activate", bounceID)
 	err := client.doRequest(Options{
-		Method:             "PUT",
-		Path:               path,
-		IncludeServerToken: true,
+		Method:    "PUT",
+		Path:      path,
+		TokenType: server_token,
 	}, &res)
 	return res.Bounce, res.Message, err
 }
@@ -173,9 +173,9 @@ func (client *Client) GetBouncedTags() ([]string, error) {
 	var raw json.RawMessage
 	path := "bounces/tags"
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               path,
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      path,
+		TokenType: server_token,
 	}, &raw)
 
 	if err != nil {

--- a/bounce.go
+++ b/bounce.go
@@ -33,7 +33,12 @@ type DeliveryStats struct {
 func (client *Client) GetDeliveryStats() (DeliveryStats, error) {
 	res := DeliveryStats{}
 	path := "deliverystats"
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               path,
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -62,7 +67,7 @@ type Bounce struct {
 	Email string
 	// BouncedAt: Timestamp of bounce
 	BouncedAt time.Time
-	// DumpAvailable: Specifies whether or not you can get a raw dump from this bounce. Postmark doesn’t store bounce dumps older than 30 days.
+	// DumpAvailable: Specifies whether or not you can get a raw dump from this bounce. Postmark does not store bounce dumps older than 30 days.
 	DumpAvailable bool
 	// Inactive: Specifies if the bounce caused Postmark to deactivate this email.
 	Inactive bool
@@ -93,7 +98,12 @@ func (client *Client) GetBounces(count int64, offset int64, options map[string]i
 
 	path := fmt.Sprintf("bounces?%s", values.Encode())
 
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               path,
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 	return res.Bounces, res.TotalCount, err
 }
 
@@ -104,7 +114,12 @@ func (client *Client) GetBounces(count int64, offset int64, options map[string]i
 func (client *Client) GetBounce(bounceID int64) (Bounce, error) {
 	res := Bounce{}
 	path := fmt.Sprintf("bounces/%v", bounceID)
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               path,
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -119,7 +134,12 @@ type dumpResponse struct {
 func (client *Client) GetBounceDump(bounceID int64) (string, error) {
 	res := dumpResponse{}
 	path := fmt.Sprintf("bounces/%v/dump", bounceID)
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               path,
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 	return res.Body, err
 }
 
@@ -137,7 +157,12 @@ type activateBounceResponse struct {
 func (client *Client) ActivateBounce(bounceID int64) (Bounce, string, error) {
 	res := activateBounceResponse{}
 	path := fmt.Sprintf("bounces/%v/activate", bounceID)
-	err := client.doRequest("PUT", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "PUT",
+		Path:               path,
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 	return res.Bounce, res.Message, err
 }
 
@@ -151,8 +176,13 @@ type bouncedTagsResponse struct {
 // GetBouncedTags retrieves a list of tags that have generated bounced emails
 func (client *Client) GetBouncedTags() ([]string, error) {
 	var raw json.RawMessage
-	path := fmt.Sprintf("bounces/tags")
-	err := client.doRequest("GET", path, nil, &raw)
+	path := "bounces/tags"
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               path,
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &raw)
 
 	if err != nil {
 		return []string{}, err

--- a/bounce.go
+++ b/bounce.go
@@ -36,7 +36,6 @@ func (client *Client) GetDeliveryStats() (DeliveryStats, error) {
 	err := client.doRequest(Options{
 		Method:             "GET",
 		Path:               path,
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 	return res, err
@@ -101,7 +100,6 @@ func (client *Client) GetBounces(count int64, offset int64, options map[string]i
 	err := client.doRequest(Options{
 		Method:             "GET",
 		Path:               path,
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 	return res.Bounces, res.TotalCount, err
@@ -117,7 +115,6 @@ func (client *Client) GetBounce(bounceID int64) (Bounce, error) {
 	err := client.doRequest(Options{
 		Method:             "GET",
 		Path:               path,
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 	return res, err
@@ -137,7 +134,6 @@ func (client *Client) GetBounceDump(bounceID int64) (string, error) {
 	err := client.doRequest(Options{
 		Method:             "GET",
 		Path:               path,
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 	return res.Body, err
@@ -160,7 +156,6 @@ func (client *Client) ActivateBounce(bounceID int64) (Bounce, string, error) {
 	err := client.doRequest(Options{
 		Method:             "PUT",
 		Path:               path,
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 	return res.Bounce, res.Message, err
@@ -180,7 +175,6 @@ func (client *Client) GetBouncedTags() ([]string, error) {
 	err := client.doRequest(Options{
 		Method:             "GET",
 		Path:               path,
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &raw)
 

--- a/bounce.go
+++ b/bounce.go
@@ -33,7 +33,7 @@ type DeliveryStats struct {
 func (client *Client) GetDeliveryStats() (DeliveryStats, error) {
 	res := DeliveryStats{}
 	path := "deliverystats"
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      path,
 		TokenType: server_token,
@@ -97,7 +97,7 @@ func (client *Client) GetBounces(count int64, offset int64, options map[string]i
 
 	path := fmt.Sprintf("bounces?%s", values.Encode())
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      path,
 		TokenType: server_token,
@@ -112,7 +112,7 @@ func (client *Client) GetBounces(count int64, offset int64, options map[string]i
 func (client *Client) GetBounce(bounceID int64) (Bounce, error) {
 	res := Bounce{}
 	path := fmt.Sprintf("bounces/%v", bounceID)
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      path,
 		TokenType: server_token,
@@ -131,7 +131,7 @@ type dumpResponse struct {
 func (client *Client) GetBounceDump(bounceID int64) (string, error) {
 	res := dumpResponse{}
 	path := fmt.Sprintf("bounces/%v/dump", bounceID)
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      path,
 		TokenType: server_token,
@@ -153,7 +153,7 @@ type activateBounceResponse struct {
 func (client *Client) ActivateBounce(bounceID int64) (Bounce, string, error) {
 	res := activateBounceResponse{}
 	path := fmt.Sprintf("bounces/%v/activate", bounceID)
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "PUT",
 		Path:      path,
 		TokenType: server_token,
@@ -172,7 +172,7 @@ type bouncedTagsResponse struct {
 func (client *Client) GetBouncedTags() ([]string, error) {
 	var raw json.RawMessage
 	path := "bounces/tags"
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      path,
 		TokenType: server_token,

--- a/email.go
+++ b/email.go
@@ -69,7 +69,7 @@ type EmailResponse struct {
 // SendEmail sends, well, an email.
 func (client *Client) SendEmail(email Email) (EmailResponse, error) {
 	res := EmailResponse{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "POST",
 		Path:      "email",
 		Payload:   email,
@@ -88,7 +88,7 @@ func (client *Client) SendEmail(email Email) (EmailResponse, error) {
 // range over the responses and sniff for errors
 func (client *Client) SendEmailBatch(emails []Email) ([]EmailResponse, error) {
 	res := []EmailResponse{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "POST",
 		Path:      "email/batch",
 		Payload:   emails,

--- a/email.go
+++ b/email.go
@@ -69,7 +69,12 @@ type EmailResponse struct {
 // SendEmail sends, well, an email.
 func (client *Client) SendEmail(email Email) (EmailResponse, error) {
 	res := EmailResponse{}
-	err := client.doRequest("POST", "email", email, &res)
+	err := client.doRequest(Options{
+		Method:             "POST",
+		Path:               "email",
+		Payload:            email,
+		IncludeServerToken: true,
+	}, &res)
 
 	if res.ErrorCode != 0 {
 		return res, fmt.Errorf(`%v %s`, res.ErrorCode, res.Message)
@@ -83,6 +88,11 @@ func (client *Client) SendEmail(email Email) (EmailResponse, error) {
 // range over the responses and sniff for errors
 func (client *Client) SendEmailBatch(emails []Email) ([]EmailResponse, error) {
 	res := []EmailResponse{}
-	err := client.doRequest("POST", "email/batch", emails, &res)
+	err := client.doRequest(Options{
+		Method:             "POST",
+		Path:               "email/batch",
+		Payload:            emails,
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }

--- a/email.go
+++ b/email.go
@@ -70,10 +70,10 @@ type EmailResponse struct {
 func (client *Client) SendEmail(email Email) (EmailResponse, error) {
 	res := EmailResponse{}
 	err := client.doRequest(Options{
-		Method:             "POST",
-		Path:               "email",
-		Payload:            email,
-		IncludeServerToken: true,
+		Method:    "POST",
+		Path:      "email",
+		Payload:   email,
+		TokenType: server_token,
 	}, &res)
 
 	if res.ErrorCode != 0 {
@@ -89,10 +89,10 @@ func (client *Client) SendEmail(email Email) (EmailResponse, error) {
 func (client *Client) SendEmailBatch(emails []Email) ([]EmailResponse, error) {
 	res := []EmailResponse{}
 	err := client.doRequest(Options{
-		Method:             "POST",
-		Path:               "email/batch",
-		Payload:            emails,
-		IncludeServerToken: true,
+		Method:    "POST",
+		Path:      "email/batch",
+		Payload:   emails,
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }

--- a/messages_inbound.go
+++ b/messages_inbound.go
@@ -62,7 +62,7 @@ func (x InboundMessage) Time() (time.Time, error) {
 // GetInboundMessage fetches a specific inbound message via serverID
 func (client *Client) GetInboundMessage(messageID string) (InboundMessage, error) {
 	res := InboundMessage{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("messages/inbound/%s/details", messageID),
 		TokenType: server_token,
@@ -92,7 +92,7 @@ func (client *Client) GetInboundMessages(count int64, offset int64, options map[
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("messages/inbound?%s", values.Encode()),
 		TokenType: server_token,
@@ -107,7 +107,7 @@ func (client *Client) GetInboundMessages(count int64, offset int64, options map[
 // BypassInboundMessage - Bypass rules for a blocked inbound message
 func (client *Client) BypassInboundMessage(messageID string) error {
 	res := APIError{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "PUT",
 		Path:      fmt.Sprintf("messages/inbound/%s/bypass", messageID),
 		TokenType: server_token,
@@ -126,7 +126,7 @@ func (client *Client) BypassInboundMessage(messageID string) error {
 // RetryInboundMessage - Retry a failed inbound message for processing
 func (client *Client) RetryInboundMessage(messageID string) error {
 	res := APIError{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "PUT",
 		Path:      fmt.Sprintf("messages/inbound/%s/retry", messageID),
 		TokenType: server_token,

--- a/messages_inbound.go
+++ b/messages_inbound.go
@@ -62,8 +62,12 @@ func (x InboundMessage) Time() (time.Time, error) {
 // GetInboundMessage fetches a specific inbound message via serverID
 func (client *Client) GetInboundMessage(messageID string) (InboundMessage, error) {
 	res := InboundMessage{}
-	path := fmt.Sprintf("messages/inbound/%s/details", messageID)
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("messages/inbound/%s/details", messageID),
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -89,9 +93,13 @@ func (client *Client) GetInboundMessages(count int64, offset int64, options map[
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("messages/inbound?%s", values.Encode())
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("messages/inbound?%s", values.Encode()),
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 
-	err := client.doRequest("GET", path, nil, &res)
 	return res.Messages, res.TotalCount, err
 }
 
@@ -101,8 +109,12 @@ func (client *Client) GetInboundMessages(count int64, offset int64, options map[
 // BypassInboundMessage - Bypass rules for a blocked inbound message
 func (client *Client) BypassInboundMessage(messageID string) error {
 	res := APIError{}
-	path := fmt.Sprintf("messages/inbound/%s/bypass", messageID)
-	err := client.doRequest("PUT", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "PUT",
+		Path:               fmt.Sprintf("messages/inbound/%s/bypass", messageID),
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 
 	if res.ErrorCode != 0 {
 		return res
@@ -117,8 +129,12 @@ func (client *Client) BypassInboundMessage(messageID string) error {
 // RetryInboundMessage - Retry a failed inbound message for processing
 func (client *Client) RetryInboundMessage(messageID string) error {
 	res := APIError{}
-	path := fmt.Sprintf("messages/inbound/%s/retry", messageID)
-	err := client.doRequest("PUT", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "PUT",
+		Path:               fmt.Sprintf("messages/inbound/%s/retry", messageID),
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 
 	if res.ErrorCode != 0 {
 		return res

--- a/messages_inbound.go
+++ b/messages_inbound.go
@@ -65,7 +65,6 @@ func (client *Client) GetInboundMessage(messageID string) (InboundMessage, error
 	err := client.doRequest(Options{
 		Method:             "GET",
 		Path:               fmt.Sprintf("messages/inbound/%s/details", messageID),
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 	return res, err
@@ -96,7 +95,6 @@ func (client *Client) GetInboundMessages(count int64, offset int64, options map[
 	err := client.doRequest(Options{
 		Method:             "GET",
 		Path:               fmt.Sprintf("messages/inbound?%s", values.Encode()),
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 
@@ -112,7 +110,6 @@ func (client *Client) BypassInboundMessage(messageID string) error {
 	err := client.doRequest(Options{
 		Method:             "PUT",
 		Path:               fmt.Sprintf("messages/inbound/%s/bypass", messageID),
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 
@@ -132,7 +129,6 @@ func (client *Client) RetryInboundMessage(messageID string) error {
 	err := client.doRequest(Options{
 		Method:             "PUT",
 		Path:               fmt.Sprintf("messages/inbound/%s/retry", messageID),
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 

--- a/messages_inbound.go
+++ b/messages_inbound.go
@@ -63,9 +63,9 @@ func (x InboundMessage) Time() (time.Time, error) {
 func (client *Client) GetInboundMessage(messageID string) (InboundMessage, error) {
 	res := InboundMessage{}
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("messages/inbound/%s/details", messageID),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("messages/inbound/%s/details", messageID),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -93,9 +93,9 @@ func (client *Client) GetInboundMessages(count int64, offset int64, options map[
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("messages/inbound?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("messages/inbound?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 
 	return res.Messages, res.TotalCount, err
@@ -108,9 +108,9 @@ func (client *Client) GetInboundMessages(count int64, offset int64, options map[
 func (client *Client) BypassInboundMessage(messageID string) error {
 	res := APIError{}
 	err := client.doRequest(Options{
-		Method:             "PUT",
-		Path:               fmt.Sprintf("messages/inbound/%s/bypass", messageID),
-		IncludeServerToken: true,
+		Method:    "PUT",
+		Path:      fmt.Sprintf("messages/inbound/%s/bypass", messageID),
+		TokenType: server_token,
 	}, &res)
 
 	if res.ErrorCode != 0 {
@@ -127,9 +127,9 @@ func (client *Client) BypassInboundMessage(messageID string) error {
 func (client *Client) RetryInboundMessage(messageID string) error {
 	res := APIError{}
 	err := client.doRequest(Options{
-		Method:             "PUT",
-		Path:               fmt.Sprintf("messages/inbound/%s/retry", messageID),
-		IncludeServerToken: true,
+		Method:    "PUT",
+		Path:      fmt.Sprintf("messages/inbound/%s/retry", messageID),
+		TokenType: server_token,
 	}, &res)
 
 	if res.ErrorCode != 0 {

--- a/messages_outbound.go
+++ b/messages_outbound.go
@@ -66,9 +66,9 @@ type MessageEvent struct {
 func (client *Client) GetOutboundMessage(messageID string) (OutboundMessage, error) {
 	res := OutboundMessage{}
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("messages/outbound/%s/details", messageID),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("messages/outbound/%s/details", messageID),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -80,9 +80,9 @@ func (client *Client) GetOutboundMessage(messageID string) (OutboundMessage, err
 func (client *Client) GetOutboundMessageDump(messageID string) (string, error) {
 	res := dumpResponse{}
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("messages/outbound/%s/dump", messageID),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("messages/outbound/%s/dump", messageID),
+		TokenType: server_token,
 	}, &res)
 	return res.Body, err
 }
@@ -111,9 +111,9 @@ func (client *Client) GetOutboundMessages(count int64, offset int64, options map
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("messages/outbound?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("messages/outbound?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res.Messages, res.TotalCount, err
 }
@@ -162,9 +162,9 @@ func (client *Client) GetOutboundMessagesOpens(count int64, offset int64, option
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("messages/outbound/opens?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("messages/outbound/opens?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res.Opens, res.TotalCount, err
 }
@@ -182,9 +182,9 @@ func (client *Client) GetOutboundMessageOpens(messageID string, count int64, off
 	values.Add("offset", fmt.Sprintf("%d", offset))
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("messages/outbound/opens/%s?%s", messageID, values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("messages/outbound/opens/%s?%s", messageID, values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res.Opens, res.TotalCount, err
 }

--- a/messages_outbound.go
+++ b/messages_outbound.go
@@ -68,7 +68,6 @@ func (client *Client) GetOutboundMessage(messageID string) (OutboundMessage, err
 	err := client.doRequest(Options{
 		Method:             "GET",
 		Path:               fmt.Sprintf("messages/outbound/%s/details", messageID),
-		Payload:            nil,
 		IncludeServerToken: true,
 	}, &res)
 	return res, err

--- a/messages_outbound.go
+++ b/messages_outbound.go
@@ -65,7 +65,7 @@ type MessageEvent struct {
 // GetOutboundMessage fetches a specific outbound message via serverID
 func (client *Client) GetOutboundMessage(messageID string) (OutboundMessage, error) {
 	res := OutboundMessage{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("messages/outbound/%s/details", messageID),
 		TokenType: server_token,
@@ -79,7 +79,7 @@ func (client *Client) GetOutboundMessage(messageID string) (OutboundMessage, err
 // GetOutboundMessageDump fetches the raw source of message. If no dump is available this will return an empty string.
 func (client *Client) GetOutboundMessageDump(messageID string) (string, error) {
 	res := dumpResponse{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("messages/outbound/%s/dump", messageID),
 		TokenType: server_token,
@@ -110,7 +110,7 @@ func (client *Client) GetOutboundMessages(count int64, offset int64, options map
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("messages/outbound?%s", values.Encode()),
 		TokenType: server_token,
@@ -161,7 +161,7 @@ func (client *Client) GetOutboundMessagesOpens(count int64, offset int64, option
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("messages/outbound/opens?%s", values.Encode()),
 		TokenType: server_token,
@@ -181,7 +181,7 @@ func (client *Client) GetOutboundMessageOpens(messageID string, count int64, off
 	values.Add("count", fmt.Sprintf("%d", count))
 	values.Add("offset", fmt.Sprintf("%d", offset))
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("messages/outbound/opens/%s?%s", messageID, values.Encode()),
 		TokenType: server_token,

--- a/messages_outbound.go
+++ b/messages_outbound.go
@@ -40,7 +40,7 @@ type OutboundMessage struct {
 	MessageEvents []MessageEvent
 }
 
-// Recipient represents an indiviual who received a message
+// Recipient represents an individual who received a message
 type Recipient struct {
 	// Name is the recipient's name
 	Name string
@@ -65,8 +65,12 @@ type MessageEvent struct {
 // GetOutboundMessage fetches a specific outbound message via serverID
 func (client *Client) GetOutboundMessage(messageID string) (OutboundMessage, error) {
 	res := OutboundMessage{}
-	path := fmt.Sprintf("messages/outbound/%s/details", messageID)
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("messages/outbound/%s/details", messageID),
+		Payload:            nil,
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -76,8 +80,11 @@ func (client *Client) GetOutboundMessage(messageID string) (OutboundMessage, err
 // GetOutboundMessageDump fetches the raw source of message. If no dump is available this will return an empty string.
 func (client *Client) GetOutboundMessageDump(messageID string) (string, error) {
 	res := dumpResponse{}
-	path := fmt.Sprintf("messages/outbound/%s/dump", messageID)
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("messages/outbound/%s/dump", messageID),
+		IncludeServerToken: true,
+	}, &res)
 	return res.Body, err
 }
 
@@ -104,9 +111,11 @@ func (client *Client) GetOutboundMessages(count int64, offset int64, options map
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("messages/outbound?%s", values.Encode())
-
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("messages/outbound?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res.Messages, res.TotalCount, err
 }
 
@@ -117,7 +126,7 @@ func (client *Client) GetOutboundMessages(count int64, offset int64, options map
 type Open struct {
 	// FirstOpen - Indicates if the open was first open of message with MessageID and by Recipient. Any subsequent opens of the same message by the same Recipient will show false in this field. Postmark only saves first opens to its store, while all opens are available via Open web hooks.
 	FirstOpen bool
-	// UserAgent - Full user-agentheader passed by the client software to Postmark. Postmark will fill in the Platform Client and OS fields based on this.
+	// UserAgent - Full user-agent header passed by the client software to Postmark. Postmark will fill in the Platform Client and OS fields based on this.
 	UserAgent string
 	// MessageID - Unique ID of the message.
 	MessageID string
@@ -153,9 +162,11 @@ func (client *Client) GetOutboundMessagesOpens(count int64, offset int64, option
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("messages/outbound/opens?%s", values.Encode())
-
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("messages/outbound/opens?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res.Opens, res.TotalCount, err
 }
 
@@ -171,8 +182,10 @@ func (client *Client) GetOutboundMessageOpens(messageID string, count int64, off
 	values.Add("count", fmt.Sprintf("%d", count))
 	values.Add("offset", fmt.Sprintf("%d", offset))
 
-	path := fmt.Sprintf("messages/outbound/opens/%s?%s", messageID, values.Encode())
-
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("messages/outbound/opens/%s?%s", messageID, values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res.Opens, res.TotalCount, err
 }

--- a/postmark.go
+++ b/postmark.go
@@ -25,16 +25,17 @@ type Client struct {
 	BaseURL string
 }
 
+// Options is an object to hold variable parameters to perform request.
 type Options struct {
-	// HTTP method to perform.
+	// Method is HTTP method type.
 	Method              string
-	// URI.
+	// Path is postfix for URI.
 	Path                string
-	// Body payload.
+	// Payload for the request.
 	Payload             interface{}
-	// Whether server token header has to be included.
+	// IncludeServerToken indicates server token header has to be included.
 	IncludeServerToken  bool
-	// Whether account token header has to be included
+	// IncludeAccountToken indicates whether account token header has to be included.
 	IncludeAccountToken bool
 }
 

--- a/postmark.go
+++ b/postmark.go
@@ -25,18 +25,21 @@ type Client struct {
 	BaseURL string
 }
 
+const (
+	server_token  = "server"
+	account_token = "account"
+)
+
 // Options is an object to hold variable parameters to perform request.
 type Options struct {
 	// Method is HTTP method type.
-	Method              string
+	Method string
 	// Path is postfix for URI.
-	Path                string
+	Path string
 	// Payload for the request.
-	Payload             interface{}
-	// IncludeServerToken indicates server token header has to be included.
-	IncludeServerToken  bool
-	// IncludeAccountToken indicates whether account token header has to be included.
-	IncludeAccountToken bool
+	Payload interface{}
+	// TokenType defines which token to use
+	TokenType string
 }
 
 // NewClient builds a new Client pointer using the provided tokens, a default HTTPClient, and a default API base URL
@@ -70,12 +73,12 @@ func (client *Client) doRequest(options Options, dst interface{}) error {
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 
-	if options.IncludeServerToken {
-		req.Header.Add("X-Postmark-Server-Token", client.ServerToken)
-	}
-
-	if options.IncludeAccountToken {
+	switch options.TokenType {
+	case account_token:
 		req.Header.Add("X-Postmark-Account-Token", client.AccountToken)
+
+	default:
+		req.Header.Add("X-Postmark-Server-Token", client.ServerToken)
 	}
 
 	res, err := client.HTTPClient.Do(req)

--- a/postmark.go
+++ b/postmark.go
@@ -31,7 +31,7 @@ const (
 )
 
 // Options is an object to hold variable parameters to perform request.
-type Options struct {
+type parameters struct {
 	// Method is HTTP method type.
 	Method string
 	// Path is postfix for URI.
@@ -54,16 +54,16 @@ func NewClient(serverToken string, accountToken string) *Client {
 	}
 }
 
-func (client *Client) doRequest(options Options, dst interface{}) error {
-	url := fmt.Sprintf("%s/%s", client.BaseURL, options.Path)
+func (client *Client) doRequest(opts parameters, dst interface{}) error {
+	url := fmt.Sprintf("%s/%s", client.BaseURL, opts.Path)
 
-	req, err := http.NewRequest(options.Method, url, nil)
+	req, err := http.NewRequest(opts.Method, url, nil)
 	if err != nil {
 		return err
 	}
 
-	if options.Payload != nil {
-		payloadData, err := json.Marshal(options.Payload)
+	if opts.Payload != nil {
+		payloadData, err := json.Marshal(opts.Payload)
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func (client *Client) doRequest(options Options, dst interface{}) error {
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 
-	switch options.TokenType {
+	switch opts.TokenType {
 	case account_token:
 		req.Header.Add("X-Postmark-Account-Token", client.AccountToken)
 

--- a/servers.go
+++ b/servers.go
@@ -14,7 +14,7 @@ type Server struct {
 	ApiTokens []string
 	// ServerLink to your server overview page in Postmark.
 	ServerLink string
-	// Color of the server in the rack screen. Purple Blue Turqoise Green Red Yellow Grey
+	// Color of the server in the rack screen. Purple Blue Turquoise Green Red Yellow Grey
 	Color string
 	// SmtpApiActivated specifies whether or not SMTP is enabled on this server.
 	SmtpApiActivated bool
@@ -22,11 +22,11 @@ type Server struct {
 	RawEmailEnabled bool
 	// InboundAddress is the inbound email address
 	InboundAddress string
-	// InboundHookUrl to POST to everytime an inbound event occurs.
+	// InboundHookUrl to POST to every time an inbound event occurs.
 	InboundHookUrl string
-	// BounceHookUrl to POST to everytime a bounce event occurs.
+	// BounceHookUrl to POST to every time a bounce event occurs.
 	BounceHookUrl string
-	// OpenHookUrl to POST to everytime an open event occurs.
+	// OpenHookUrl to POST to every time an open event occurs.
 	OpenHookUrl string
 	// PostFirstOpenOnly - If set to true, only the first open by a particular recipient will initiate the open webhook. Any
 	// subsequent opens of the same email by the same recipient will not initiate the webhook.
@@ -47,8 +47,11 @@ type Server struct {
 // GetServer fetches a specific server via serverID
 func (client *Client) GetServer(serverID string) (Server, error) {
 	res := Server{}
-	path := fmt.Sprintf("servers/%s", serverID)
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:              "GET",
+		Path:                fmt.Sprintf("servers/%s", serverID),
+		IncludeAccountToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -58,7 +61,10 @@ func (client *Client) GetServer(serverID string) (Server, error) {
 // EditServer updates details for a specific server with serverID
 func (client *Client) EditServer(serverID string, server Server) (Server, error) {
 	res := Server{}
-	path := fmt.Sprintf("servers/%s", serverID)
-	err := client.doRequest("PUT", path, server, &res)
+	err := client.doRequest(Options{
+		Method:              "PUT",
+		Path:                fmt.Sprintf("servers/%s", serverID),
+		IncludeAccountToken: true,
+	}, &res)
 	return res, err
 }

--- a/servers.go
+++ b/servers.go
@@ -47,7 +47,7 @@ type Server struct {
 // GetServer fetches a specific server via serverID
 func (client *Client) GetServer(serverID string) (Server, error) {
 	res := Server{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("servers/%s", serverID),
 		TokenType: account_token,
@@ -61,7 +61,7 @@ func (client *Client) GetServer(serverID string) (Server, error) {
 // EditServer updates details for a specific server with serverID
 func (client *Client) EditServer(serverID string, server Server) (Server, error) {
 	res := Server{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "PUT",
 		Path:      fmt.Sprintf("servers/%s", serverID),
 		TokenType: account_token,

--- a/servers.go
+++ b/servers.go
@@ -48,9 +48,9 @@ type Server struct {
 func (client *Client) GetServer(serverID string) (Server, error) {
 	res := Server{}
 	err := client.doRequest(Options{
-		Method:              "GET",
-		Path:                fmt.Sprintf("servers/%s", serverID),
-		IncludeAccountToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("servers/%s", serverID),
+		TokenType: account_token,
 	}, &res)
 	return res, err
 }
@@ -62,9 +62,9 @@ func (client *Client) GetServer(serverID string) (Server, error) {
 func (client *Client) EditServer(serverID string, server Server) (Server, error) {
 	res := Server{}
 	err := client.doRequest(Options{
-		Method:              "PUT",
-		Path:                fmt.Sprintf("servers/%s", serverID),
-		IncludeAccountToken: true,
+		Method:    "PUT",
+		Path:      fmt.Sprintf("servers/%s", serverID),
+		TokenType: account_token,
 	}, &res)
 	return res, err
 }

--- a/stats.go
+++ b/stats.go
@@ -47,9 +47,9 @@ func (client *Client) GetOutboundStats(options map[string]interface{}) (Outbound
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("stats/outbound?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("stats/outbound?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -83,9 +83,9 @@ func (client *Client) GetSentCounts(options map[string]interface{}) (SendCounts,
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("stats/outbound/sends?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("stats/outbound/sends?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -131,9 +131,9 @@ func (client *Client) GetBounceCounts(options map[string]interface{}) (BounceCou
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("stats/outbound/bounces?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("stats/outbound/bounces?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -168,9 +168,9 @@ func (client *Client) GetSpamCounts(options map[string]interface{}) (SpamCounts,
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("stats/outbound/spam?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("stats/outbound/spam?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -204,9 +204,9 @@ func (client *Client) GetTrackedCounts(options map[string]interface{}) (TrackedC
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("stats/outbound/tracked?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("stats/outbound/tracked?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -244,9 +244,9 @@ func (client *Client) GetOpenCounts(options map[string]interface{}) (OpenCounts,
 	}
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("stats/outbound/opens?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("stats/outbound/opens?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }

--- a/stats.go
+++ b/stats.go
@@ -46,7 +46,7 @@ func (client *Client) GetOutboundStats(options map[string]interface{}) (Outbound
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("stats/outbound?%s", values.Encode()),
 		TokenType: server_token,
@@ -82,7 +82,7 @@ func (client *Client) GetSentCounts(options map[string]interface{}) (SendCounts,
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("stats/outbound/sends?%s", values.Encode()),
 		TokenType: server_token,
@@ -130,7 +130,7 @@ func (client *Client) GetBounceCounts(options map[string]interface{}) (BounceCou
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("stats/outbound/bounces?%s", values.Encode()),
 		TokenType: server_token,
@@ -167,7 +167,7 @@ func (client *Client) GetSpamCounts(options map[string]interface{}) (SpamCounts,
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("stats/outbound/spam?%s", values.Encode()),
 		TokenType: server_token,
@@ -203,7 +203,7 @@ func (client *Client) GetTrackedCounts(options map[string]interface{}) (TrackedC
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("stats/outbound/tracked?%s", values.Encode()),
 		TokenType: server_token,
@@ -243,7 +243,7 @@ func (client *Client) GetOpenCounts(options map[string]interface{}) (OpenCounts,
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("stats/outbound/opens?%s", values.Encode()),
 		TokenType: server_token,

--- a/stats.go
+++ b/stats.go
@@ -46,8 +46,11 @@ func (client *Client) GetOutboundStats(options map[string]interface{}) (Outbound
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("stats/outbound?%s", values.Encode())
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("stats/outbound?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -66,7 +69,7 @@ type SendDay struct {
 type SendCounts struct {
 	// Days - List of objects that each represent sent counts by date.
 	Days []SendDay
-	// Sent - Indiciates the number of total sent emails returned.
+	// Sent - Indicates the number of total sent emails returned.
 	Sent int64
 }
 
@@ -79,8 +82,11 @@ func (client *Client) GetSentCounts(options map[string]interface{}) (SendCounts,
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("stats/outbound/sends?%s", values.Encode())
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("stats/outbound/sends?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -124,23 +130,26 @@ func (client *Client) GetBounceCounts(options map[string]interface{}) (BounceCou
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("stats/outbound/bounces?%s", values.Encode())
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("stats/outbound/bounces?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
 ///////////////////////////////////////
 ///////////////////////////////////////
 
-// SpamDay - spam compaints for a specific day
+// SpamDay - spam complaints for a specific day
 type SpamDay struct {
 	// Date - prettttay self explanatory
 	Date string
-	// SpamComplaint - number of spam compaints received
+	// SpamComplaint - number of spam complaints received
 	SpamComplaint int64
 }
 
-// SpamCounts - spam compaints for a period
+// SpamCounts - spam complaints for a period
 type SpamCounts struct {
 	// Days - List of objects that each represent spam complaint counts by date.
 	Days []SpamDay
@@ -149,7 +158,7 @@ type SpamCounts struct {
 }
 
 // GetSpamCounts - Gets a total count of recipients who have marked your email as spam.
-// Days that didn’t produce statistics won’t appear in the JSON response.
+// Days that did not produce statistics won’t appear in the JSON response.
 // Available options: http://developer.postmarkapp.com/developer-api-stats.html#spam-complaints
 func (client *Client) GetSpamCounts(options map[string]interface{}) (SpamCounts, error) {
 	res := SpamCounts{}
@@ -158,8 +167,11 @@ func (client *Client) GetSpamCounts(options map[string]interface{}) (SpamCounts,
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("stats/outbound/spam?%s", values.Encode())
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("stats/outbound/spam?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -191,8 +203,11 @@ func (client *Client) GetTrackedCounts(options map[string]interface{}) (TrackedC
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("stats/outbound/tracked?%s", values.Encode())
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("stats/outbound/tracked?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -228,7 +243,10 @@ func (client *Client) GetOpenCounts(options map[string]interface{}) (OpenCounts,
 		values.Add(k, fmt.Sprintf("%v", v))
 	}
 
-	path := fmt.Sprintf("stats/outbound/opens?%s", values.Encode())
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("stats/outbound/opens?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }

--- a/templates.go
+++ b/templates.go
@@ -39,7 +39,7 @@ type TemplateInfo struct {
 // GetTemplate fetches a specific template via TemplateID
 func (client *Client) GetTemplate(templateID string) (Template, error) {
 	res := Template{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("templates/%s", templateID),
 		TokenType: server_token,
@@ -66,7 +66,7 @@ func (client *Client) GetTemplates(count int64, offset int64) ([]TemplateInfo, i
 	values.Add("count", fmt.Sprintf("%d", count))
 	values.Add("offset", fmt.Sprintf("%d", offset))
 
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "GET",
 		Path:      fmt.Sprintf("templates?%s", values.Encode()),
 		TokenType: server_token,
@@ -80,7 +80,7 @@ func (client *Client) GetTemplates(count int64, offset int64) ([]TemplateInfo, i
 // CreateTemplate saves a new template to the server
 func (client *Client) CreateTemplate(template Template) (TemplateInfo, error) {
 	res := TemplateInfo{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "POST",
 		Path:      "templates",
 		Payload:   template,
@@ -95,7 +95,7 @@ func (client *Client) CreateTemplate(template Template) (TemplateInfo, error) {
 // EditTemplate updates details for a specific template with templateID
 func (client *Client) EditTemplate(templateID string, template Template) (TemplateInfo, error) {
 	res := TemplateInfo{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "PUT",
 		Path:      fmt.Sprintf("templates/%s", templateID),
 		Payload:   template,
@@ -110,7 +110,7 @@ func (client *Client) EditTemplate(templateID string, template Template) (Templa
 // DeleteTemplate removes a template (with templateID) from the server
 func (client *Client) DeleteTemplate(templateID string) error {
 	res := APIError{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "DELETE",
 		Path:      fmt.Sprintf("templates/%s", templateID),
 		TokenType: server_token,
@@ -157,7 +157,7 @@ type TemplatedEmail struct {
 // SendTemplatedEmail sends an email using a template (TemplateId)
 func (client *Client) SendTemplatedEmail(email TemplatedEmail) (EmailResponse, error) {
 	res := EmailResponse{}
-	err := client.doRequest(Options{
+	err := client.doRequest(parameters{
 		Method:    "POST",
 		Path:      "email/withTemplate",
 		Payload:   email,

--- a/templates.go
+++ b/templates.go
@@ -39,8 +39,11 @@ type TemplateInfo struct {
 // GetTemplate fetches a specific template via TemplateID
 func (client *Client) GetTemplate(templateID string) (Template, error) {
 	res := Template{}
-	path := fmt.Sprintf("templates/%s", templateID)
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("templates/%s", templateID),
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -63,9 +66,11 @@ func (client *Client) GetTemplates(count int64, offset int64) ([]TemplateInfo, i
 	values.Add("count", fmt.Sprintf("%d", count))
 	values.Add("offset", fmt.Sprintf("%d", offset))
 
-	path := fmt.Sprintf("templates?%s", values.Encode())
-
-	err := client.doRequest("GET", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "GET",
+		Path:               fmt.Sprintf("templates?%s", values.Encode()),
+		IncludeServerToken: true,
+	}, &res)
 	return res.Templates, res.TotalCount, err
 }
 
@@ -75,7 +80,12 @@ func (client *Client) GetTemplates(count int64, offset int64) ([]TemplateInfo, i
 // CreateTemplate saves a new template to the server
 func (client *Client) CreateTemplate(template Template) (TemplateInfo, error) {
 	res := TemplateInfo{}
-	err := client.doRequest("POST", "templates", template, &res)
+	err := client.doRequest(Options{
+		Method:             "POST",
+		Path:               "templates",
+		Payload:            template,
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -85,8 +95,12 @@ func (client *Client) CreateTemplate(template Template) (TemplateInfo, error) {
 // EditTemplate updates details for a specific template with templateID
 func (client *Client) EditTemplate(templateID string, template Template) (TemplateInfo, error) {
 	res := TemplateInfo{}
-	path := fmt.Sprintf("templates/%s", templateID)
-	err := client.doRequest("PUT", path, template, &res)
+	err := client.doRequest(Options{
+		Method:             "PUT",
+		Path:               fmt.Sprintf("templates/%s", templateID),
+		Payload:            template,
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }
 
@@ -96,8 +110,11 @@ func (client *Client) EditTemplate(templateID string, template Template) (Templa
 // DeleteTemplate removes a template (with templateID) from the server
 func (client *Client) DeleteTemplate(templateID string) error {
 	res := APIError{}
-	path := fmt.Sprintf("templates/%s", templateID)
-	err := client.doRequest("DELETE", path, nil, &res)
+	err := client.doRequest(Options{
+		Method:             "DELETE",
+		Path:               fmt.Sprintf("templates/%s", templateID),
+		IncludeServerToken: true,
+	}, &res)
 
 	if res.ErrorCode != 0 {
 		return res
@@ -140,6 +157,11 @@ type TemplatedEmail struct {
 // SendTemplatedEmail sends an email using a template (TemplateId)
 func (client *Client) SendTemplatedEmail(email TemplatedEmail) (EmailResponse, error) {
 	res := EmailResponse{}
-	err := client.doRequest("POST", "email/withTemplate", email, &res)
+	err := client.doRequest(Options{
+		Method:             "POST",
+		Path:               "email/withTemplate",
+		Payload:            email,
+		IncludeServerToken: true,
+	}, &res)
 	return res, err
 }

--- a/templates.go
+++ b/templates.go
@@ -40,9 +40,9 @@ type TemplateInfo struct {
 func (client *Client) GetTemplate(templateID string) (Template, error) {
 	res := Template{}
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("templates/%s", templateID),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("templates/%s", templateID),
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -67,9 +67,9 @@ func (client *Client) GetTemplates(count int64, offset int64) ([]TemplateInfo, i
 	values.Add("offset", fmt.Sprintf("%d", offset))
 
 	err := client.doRequest(Options{
-		Method:             "GET",
-		Path:               fmt.Sprintf("templates?%s", values.Encode()),
-		IncludeServerToken: true,
+		Method:    "GET",
+		Path:      fmt.Sprintf("templates?%s", values.Encode()),
+		TokenType: server_token,
 	}, &res)
 	return res.Templates, res.TotalCount, err
 }
@@ -81,10 +81,10 @@ func (client *Client) GetTemplates(count int64, offset int64) ([]TemplateInfo, i
 func (client *Client) CreateTemplate(template Template) (TemplateInfo, error) {
 	res := TemplateInfo{}
 	err := client.doRequest(Options{
-		Method:             "POST",
-		Path:               "templates",
-		Payload:            template,
-		IncludeServerToken: true,
+		Method:    "POST",
+		Path:      "templates",
+		Payload:   template,
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -96,10 +96,10 @@ func (client *Client) CreateTemplate(template Template) (TemplateInfo, error) {
 func (client *Client) EditTemplate(templateID string, template Template) (TemplateInfo, error) {
 	res := TemplateInfo{}
 	err := client.doRequest(Options{
-		Method:             "PUT",
-		Path:               fmt.Sprintf("templates/%s", templateID),
-		Payload:            template,
-		IncludeServerToken: true,
+		Method:    "PUT",
+		Path:      fmt.Sprintf("templates/%s", templateID),
+		Payload:   template,
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }
@@ -111,9 +111,9 @@ func (client *Client) EditTemplate(templateID string, template Template) (Templa
 func (client *Client) DeleteTemplate(templateID string) error {
 	res := APIError{}
 	err := client.doRequest(Options{
-		Method:             "DELETE",
-		Path:               fmt.Sprintf("templates/%s", templateID),
-		IncludeServerToken: true,
+		Method:    "DELETE",
+		Path:      fmt.Sprintf("templates/%s", templateID),
+		TokenType: server_token,
 	}, &res)
 
 	if res.ErrorCode != 0 {
@@ -158,10 +158,10 @@ type TemplatedEmail struct {
 func (client *Client) SendTemplatedEmail(email TemplatedEmail) (EmailResponse, error) {
 	res := EmailResponse{}
 	err := client.doRequest(Options{
-		Method:             "POST",
-		Path:               "email/withTemplate",
-		Payload:            email,
-		IncludeServerToken: true,
+		Method:    "POST",
+		Path:      "email/withTemplate",
+		Payload:   email,
+		TokenType: server_token,
 	}, &res)
 	return res, err
 }


### PR DESCRIPTION
Explicitly set what tokens request function has to send. Otherwise, Postmark will produce an error.