### PR TITLE
Corrected Outbound Message Structure for Attachments data

### DIFF
--- a/messages_outbound.go
+++ b/messages_outbound.go
@@ -33,7 +33,7 @@ type OutboundMessage struct {
 	// Subject - Email subject
 	Subject string
 	// Attachments - List of objects that each represent an attachment.
-	Attachments []Attachment
+	Attachments []string
 	// Status - Status of message in your Postmark activity.
 	Status string
 	// MessageEvents - List of summaries (MessageEvent) of things that have happened to this message. They can be Delivered, Opened, or Bounced as shown in the type field.

--- a/messages_outbound_test.go
+++ b/messages_outbound_test.go
@@ -29,7 +29,7 @@ func TestGetOutboundMessage(t *testing.T) {
 	  "ReceivedAt": "2014-02-14T11:12:54.8054242-05:00",
 	  "From": "\"Joe\" <joe@domain.com>",
 	  "Subject": "Parts Order #5454",
-	  "Attachments": [],
+	  "Attachments": ["test-file.txt"],
 	  "Status": "Sent",
 	  "MessageEvents": [
 		{


### PR DESCRIPTION
Fixes #4.

This postmark api returns an array of filenames for the attachments field in the OutboundMessage object.

Updated the unit test as well to make sure this is tested correctly in the future.