### PR TITLE
Added support for calls to /server

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,0 +1,29 @@
+package postmark
+
+// GetThisServer gets details for the server associated
+// with the currently in-use server API Key
+func (client *Client) GetThisServer() (Server, error) {
+	res := Server{}
+	err := client.doRequest(parameters{
+		Method: "GET",
+		Path: "server",
+		TokenType: server_token,
+	}, &res)
+
+	return res, err
+}
+
+///////////////////////////////////////
+///////////////////////////////////////
+
+// EditThisServer updates details for the server associated
+// with the currently in-use server API Key
+func (client *Client) EditThisServer(server Server) (Server, error) {
+	res := Server{}
+	err := client.doRequest(parameters{
+		Method:    "PUT",
+		Path:      "server",
+		TokenType: server_token,
+	}, &res)
+	return res, err
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,90 @@
+package postmark
+
+import (
+	"testing"
+	"net/http"
+
+	"goji.io/pat"
+)
+
+func TestGetThisServer(t *testing.T) {
+	responseJSON := `{
+		"ID": 1,
+			"Name": "Staging Testing",
+			"ApiTokens": [
+		"server token"
+		],
+		"ServerLink": "https://postmarkapp.com/servers/1/overview",
+			"Color": "red",
+			"SmtpApiActivated": true,
+			"RawEmailEnabled": false,
+			"DeliveryHookUrl": "http://hooks.example.com/delivery",
+			"InboundAddress": "yourhash@inbound.postmarkapp.com",
+			"InboundHookUrl": "http://hooks.example.com/inbound",
+			"BounceHookUrl": "http://hooks.example.com/bounce",
+			"IncludeBounceContentInHook": true,
+			"OpenHookUrl": "http://hooks.example.com/open",
+			"PostFirstOpenOnly": false,
+			"TrackOpens": false,
+			"TrackLinks" : "None",
+			"ClickHookUrl" : "http://hooks.example.com/click",
+			"InboundDomain": "",
+			"InboundHash": "yourhash",
+			"InboundSpamThreshold": 0
+	}`
+
+	tMux.HandleFunc(pat.Get("/server"), func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(responseJSON))
+	})
+
+	res, err := client.GetThisServer()
+	if err != nil {
+		t.Fatalf("GetThisServer: %s", err.Error())
+	}
+
+	if res.Name != "Staging Testing" {
+		t.Fatalf("GetThisServer: wrong name!: %s", res.Name)
+	}
+}
+
+func TestEditThisServer(t *testing.T) {
+	responseJSON := `{
+  "ID": 1,
+  "Name": "Production Testing",
+  "ApiTokens": [
+    "Server Token"
+  ],
+  "ServerLink": "https://postmarkapp.com/servers/1/overview",
+  "Color": "blue",
+  "SmtpApiActivated": false,
+  "RawEmailEnabled": false,
+  "DeliveryHookUrl": "http://hooks.example.com/delivery",
+  "InboundAddress": "yourhash@inbound.postmarkapp.com",
+  "InboundHookUrl": "http://hooks.example.com/inbound",
+  "BounceHookUrl": "http://hooks.example.com/bounce",
+  "IncludeBounceContentInHook": true,
+  "OpenHookUrl": "http://hooks.example.com/open",
+  "PostFirstOpenOnly": false,
+  "TrackOpens": false,
+  "TrackLinks": "None",
+  "ClickHookUrl": "http://hooks.example.com/click",
+  "InboundDomain": "",
+  "InboundHash": "yourhash",
+  "InboundSpamThreshold": 10
+}`
+	tMux.HandleFunc(pat.Put("/server"), func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(responseJSON))
+	})
+
+	res, err := client.EditThisServer(Server{
+		Name: "Production Testing",
+	})
+
+	if err != nil {
+		t.Fatalf("EditThisServer: %s", err.Error())
+	}
+
+	if res.Name != "Production Testing" {
+		t.Fatalf("EditThisServer: wrong name!: %s", res.Name)
+	}
+}


### PR DESCRIPTION
The `postmark` package currently does not support calls to `/server`. This PR adds support for that.

While, unfortunately, I could not name the methods for this `GetServer` and `EditServer` due those already being defined, I went with the next best thing, signifying `This` in the name.

This can be changed, if needed.