### PR TITLE
Added ContentID to Attachment struct

### DIFF
--- a/email.go
+++ b/email.go
@@ -31,6 +31,8 @@ type Email struct {
 	TrackOpens bool `json:",omitempty"`
 	// Attachments: List of attachments
 	Attachments []Attachment `json:",omitempty"`
+	// Metadata: metadata
+	Metadata map[string]string `json:",omitempty"`
 }
 
 // Header - an email header


### PR DESCRIPTION
This PR adds the `ContentID` field to the `Attachment` struct. This allows for sending images inline.

I've added the field as the API documentation mentions here under **"Inline image attachments"**.
https://postmarkapp.com/developer/user-guide/sending-email/sending-with-api

This change won't have any other effects if people don't need to use it.