### PR TITLE
Get sender signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import (
 
 client := postmark.NewClient("[SERVER-TOKEN]", "[ACCOUNT-TOKEN]")
 
-email := postmark.Email{    
+email := postmark.Email{
 	From: "no-reply@example.com",
 	To: "tito@example.com",
 	Subject: "Reset your password",
@@ -88,7 +88,7 @@ client.HTTPClient = urlfetch.Client(ctx)
     * [x] `PUT /messages/inbound/:id/bypass`
     * [x] `PUT /messages/inbound/:id/retry`
 * [ ] Sender signatures
-    * [ ] List sender signatures
+    * [x] `GET /senders`
     * [ ] Get a sender signature’s details
     * [ ] Create a signature
     * [ ] Edit a signature
@@ -116,4 +116,4 @@ client.HTTPClient = urlfetch.Client(ctx)
     * [ ] Inbound rules triggers
         * [ ] Create a trigger for inbound rule
         * [ ] Delete a single trigger
-        * [ ] List triggers    
+        * [ ] List triggers

--- a/sender_signatures.go
+++ b/sender_signatures.go
@@ -21,8 +21,8 @@ type SenderSignaturesList struct {
 	SenderSignatures []SenderSignature
 }
 
-// ListSenderSignatures gets a list of sender signatures, limited by count and paged by offset
-func (client *Client) ListSenderSignatures(count, offset int64) (SenderSignaturesList, error) {
+// GetSenderSignatures gets a list of sender signatures, limited by count and paged by offset
+func (client *Client) GetSenderSignatures(count, offset int64) (SenderSignaturesList, error) {
 	res := SenderSignaturesList{}
 
 	values := &url.Values{}

--- a/sender_signatures.go
+++ b/sender_signatures.go
@@ -15,6 +15,9 @@ type SenderSignature struct {
 	ID                  int64
 }
 
+///////////////////////////////////////
+///////////////////////////////////////
+
 // SenderSignaturesList is just a list of SenderSignatures as they are in the response
 type SenderSignaturesList struct {
 	TotalCount       int

--- a/sender_signatures.go
+++ b/sender_signatures.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 )
 
+// SenderSignature contains the details of the signature of the senders
 type SenderSignature struct {
 	Domain              string
 	EmailAddress        string
@@ -14,11 +15,13 @@ type SenderSignature struct {
 	ID                  int64
 }
 
+// SenderSignaturesList is just a list of SenderSignatures as they are in the response
 type SenderSignaturesList struct {
 	TotalCount       int
 	SenderSignatures []SenderSignature
 }
 
+// ListSenderSignatures gets a list of sender signatures, limited by count and paged by offset
 func (client *Client) ListSenderSignatures(count, offset int64) (SenderSignaturesList, error) {
 	res := SenderSignaturesList{}
 

--- a/sender_signatures.go
+++ b/sender_signatures.go
@@ -1,0 +1,35 @@
+package postmark
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type SenderSignature struct {
+	Domain              string
+	EmailAddress        string
+	ReplyToEmailAddress string
+	Name                string
+	Confirmed           bool
+	ID                  int64
+}
+
+type SenderSignaturesList struct {
+	TotalCount       int
+	SenderSignatures []SenderSignature
+}
+
+func (client *Client) ListSenderSignatures(count, offset int64) (SenderSignaturesList, error) {
+	res := SenderSignaturesList{}
+
+	values := &url.Values{}
+	values.Add("count", fmt.Sprintf("%d", count))
+	values.Add("offset", fmt.Sprintf("%d", offset))
+
+	err := client.doRequest(parameters{
+		Method:    "GET",
+		Path:      fmt.Sprintf("senders?%s", values.Encode()),
+		TokenType: server_token,
+	}, &res)
+	return res, err
+}

--- a/sender_signatures_test.go
+++ b/sender_signatures_test.go
@@ -7,7 +7,7 @@ import (
 	"goji.io/pat"
 )
 
-func TestListSenderSignatures(t *testing.T) {
+func TestGetSenderSignatures(t *testing.T) {
 	responseJSON := `{
 	"TotalCount": 2,
 	"SenderSignatures": [
@@ -34,12 +34,12 @@ func TestListSenderSignatures(t *testing.T) {
 		w.Write([]byte(responseJSON))
 	})
 
-	res, err := client.ListSenderSignatures(50, 0)
+	res, err := client.GetSenderSignatures(50, 0)
 	if err != nil {
-		t.Fatalf("ListSenderSignatures: %s", err.Error())
+		t.Fatalf("GetSenderSignatures: %s", err.Error())
 	}
 
 	if res.TotalCount != 2 {
-		t.Fatalf("ListSenderSignatures: wrong name!")
+		t.Fatalf("GetSenderSignatures: wrong TotalCount!")
 	}
 }

--- a/sender_signatures_test.go
+++ b/sender_signatures_test.go
@@ -1,0 +1,45 @@
+package postmark
+
+import (
+	"net/http"
+	"testing"
+
+	"goji.io/pat"
+)
+
+func TestListSenderSignatures(t *testing.T) {
+	responseJSON := `{
+	"TotalCount": 2,
+	"SenderSignatures": [
+	  {
+		"Domain": "wildbit.com",
+		"EmailAddress": "jp@wildbit.com",
+		"ReplyToEmailAddress": "info@wildbit.com",
+		"Name": "JP Toto",
+		"Confirmed": true,
+		"ID": 36735
+	  },
+	  {
+		"Domain": "example.com",
+		"EmailAddress": "jp@example.com",
+		"ReplyToEmailAddress": "",
+		"Name": "JP Toto",
+		"Confirmed": true,
+		"ID": 81605
+	  }
+	]
+  }`
+
+	tMux.HandleFunc(pat.Get("/senders"), func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(responseJSON))
+	})
+
+	res, err := client.ListSenderSignatures(50, 0)
+	if err != nil {
+		t.Fatalf("ListSenderSignatures: %s", err.Error())
+	}
+
+	if res.TotalCount != 2 {
+		t.Fatalf("ListSenderSignatures: wrong name!")
+	}
+}


### PR DESCRIPTION
Adds the `GetSenderSignatures` endpoint wrapper and corresponding test.

Adds types:
- `SenderSignature`
- `SenderSignaturesList`